### PR TITLE
Shutaura Framework v20.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
-<img src="https://user-images.githubusercontent.com/15165770/176505424-2e88c783-7294-48d9-bb0d-ce8da8ae0302.png" width="512" /><br/>
-
----
-
-# Shutaura Framework
-
-The base framework for Sequenzia
+<img src="https://user-images.githubusercontent.com/15165770/211883603-5ef8d08d-d403-488b-a6f7-becf864c3ac4.png" width="1024" /><br/>
+The framework for Sequenzia
 
 Includes the following systems:
 * Discord I/O

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-# Kanmi Sequenzia Framework
+# Shutaura Framework
 
 The base framework for Sequenzia
 
@@ -10,11 +10,11 @@ Includes the following systems:
 * Discord I/O
 * FileWorker Upload and Download Client
 * Sync and Backup System
-* Kanmi CMS
+* Shutaura CMS
 
 ## [Click here for simple Docker compose Installation](https://github.com/UiharuKazari2008/sequenzia-compose/)
 
-## What is Kanmi / Sequenzia
+## What is Shutaura / Sequenzia
 A modular framework and ecosystem for image management and file storage using Discord as a Filesystem and CDN<br>
 
 ## Difference Sequenzia and Sequenzia II
@@ -32,21 +32,22 @@ Sequenzia II (This version) is a new system written from scratch in JavaScript o
 
 ## Terms, Names, and Language
 Before you begin setting up Sequenzia, its important to understand terms that will be thrown around:<br/>
-* Kanmi, Kanmi Framework, or Sequenzia Framework
+* Shutaura, Shutaura Framework, Kanmi, Kanmi Framework, or Sequenzia Framework
+  - Shutaura is a rebranding of Kanmi as the Kanmi name is an internal project name
   - The backend / data management side of Sequenzia
   - The stuff the users will never see
 * Sequenzia / Sequenzia Web
   - The frontend to access images and files that are stored in the database
   - The stuff users see
 * JuneFS
-  - The filesystem and structured data that comprises all data stored in Kanmi
+  - The filesystem and structured data that comprises all data stored in Shutaura
 * Spanned Files
   - Packed and Unpacked Files that are over Discords file size limit and are segmented into 8MB pieces
   - These file can not be accessed directly via the Discord CDS and require a FileWorker and Sequenzia CDS, File share, or a Web server to use
 * CDS - Sequenzia Content Distribution and Auditing System
   - Component of Sequenzia that is responsible for serving and auditing access to Unpacked Spanned Files
   - This data is stored and served from your side
-* CMS - Kanmi Content Management System
+* CMS - Shutaura Content Management System
   - A group of components and systems that are used to ingest data from sources such as Twitter, Pixiv, Flickr, RSS Feeds, Web Scrapers, etc.
   - A system within the Data Storage Servers to approve/decline incoming pending posts from Twitter, Pixiv, and Flickr
 * ADS - Sequenzia Ambient Display System
@@ -67,7 +68,7 @@ Before you begin setting up Sequenzia, its important to understand terms that wi
 * You have administrative access to your server
 * You understand at least how to use Linux some what
 * You have installed "MySQL Workbench" or another GUI tool on your workstation
-  - There are parts of Sequenzia and Kanmi that still rely on manual Database entries.
+  - There are parts of Sequenzia and Shutaura that still rely on manual Database entries.
   - MySQL WB is not a hard requirement but is what I will use for demonstrations, any tool that talks to MySQL will work
 * A Valid publicly accessible domain name with valid SSL Certificate for access outside of home
   - Free Public Domain names - https://freedns.afraid.org/

--- a/js/authware.js
+++ b/js/authware.js
@@ -962,8 +962,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 user: {
                     id: userId,
                     username: (users[0].nice_name) ? users[0].nice_name : users[0].username,
-                    avatar: (users[0].avatar_custom) ? `https://cdn.discordapp.com/attachments${users[0].avatar_custom}?size=4096` : (users[0].avatar) ? `https://cdn.discordapp.com/avatars/${userId}/${users[0].avatar}.${(users[0].avatar && users[0].avatar.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : `https://cdn.discordapp.com/embed/avatars/0.png?size=4096`,
-                    banner: (users[0].banner_custom) ? `https://cdn.discordapp.com/attachments${users[0].banner_custom}?size=4096` : (users[0].banner) ? `https://cdn.discordapp.com/banners/${userId}/${users[0].banner}.${(users[0].banner && users[0].banner.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : undefined
+                    avatar: (users[0].avatar_custom) ? `/full_attachments${users[0].avatar_custom}` : (users[0].avatar) ? `https://cdn.discordapp.com/avatars/${userId}/${users[0].avatar}.${(users[0].avatar && users[0].avatar.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : `https://cdn.discordapp.com/embed/avatars/0.png?size=4096`,
+                    banner: (users[0].banner_custom) ? `/full_attachments${users[0].banner_custom}` : (users[0].banner) ? `https://cdn.discordapp.com/banners/${userId}/${users[0].banner}.${(users[0].banner && users[0].banner.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : undefined
                 },
                 server_list: [],
                 cache: {

--- a/js/authware.js
+++ b/js/authware.js
@@ -568,7 +568,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                         if (member.roles.indexOf(data.role) === -1) {
                             if (data.approval === 1) {
                                 try {
-                                    const reqMsg = await discordClient.createMessage(staticChID.homeGuild.System, `🛎 User ${(member.nick) ? member.nick : member.user.username} from ${member.guild.name} is requesting permission "${(data.name) ? data.name : data.role}"`);
+                                    const reqMsg = await discordClient.createMessage(staticChID.homeGuild.AlrmNotif, `🛎 User ${(member.nick) ? member.nick : member.user.username} from ${member.guild.name} is requesting permission "${(data.name) ? data.name : data.role}"`);
                                     if (reqMsg && reqMsg.id) {
                                         pendingRequests.set(reqMsg.id, {
                                             data,

--- a/js/authware.js
+++ b/js/authware.js
@@ -561,8 +561,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         const userID = (user.id) ? user.id : user
         if (userID !== discordClient.user.id) {
             if (reactionmessages.indexOf(msg.id) !== -1) {
-                const data = discordreactionsroles[reactionmessages.indexOf(msg.id)];
-                if (data.emoji === emoji.name && data.server === msg.guildID) {
+                const data = discordreactionsroles.filter(e => e.message === msg.id && e.emoji === emoji.name).pop()
+                if (data) {
                     try {
                         const member = await discordClient.getRESTGuildMember(msg.guildID, userID);
                         if (member.roles.indexOf(data.role) === -1) {
@@ -572,7 +572,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                                     if (reqMsg && reqMsg.id) {
                                         pendingRequests.set(reqMsg.id, {
                                             data,
-                                            server: msg.guildID,
+                                            server: member.guild.id,
                                             user: userID
                                         })
                                         await discordClient.addMessageReaction(reqMsg.channel.id, reqMsg.id, '✅');
@@ -584,7 +584,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                             } else {
                                 let _roles = member.roles.slice();
                                 _roles.push(data.role);
-                                discordClient.editGuildMember(data.server, member.id, { roles: _roles, }, "User Granted Permission (Open Access)")
+                                discordClient.editGuildMember(member.guild.id, member.id, { roles: _roles, }, "User Granted Permission (Open Access)")
                                     .then(() => { SendMessage(`🔓 User ${(member.nick) ? member.nick : member.user.username} from ${member.guild.name} was granted ${(data.name) ? data.name : data.role} permission`, "info", 'main', "UserRightsMgr") })
                                     .catch((er) => { Logger.printLine("UserRightsMgr", `Error when trying to grant user rights to ${(member.nick) ? member.nick : member.user.username} from ${member.guild.name}`, "error", er) })
                             }
@@ -629,12 +629,12 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         const userID = (user.id) ? user.id : user
         if (userID !== discordClient.user.id) {
             if (reactionmessages.indexOf(msg.id) !== -1) {
-                const data = discordreactionsroles[reactionmessages.indexOf(msg.id)];
-                if (data.emoji === emoji.name && data.server === msg.guildID) {
+                const data = discordreactionsroles.filter(e => e.message === msg.id && e.emoji === emoji.name).pop()
+                if (data) {
                     const member = await discordClient.getRESTGuildMember(msg.guildID, userID);
                     if (member.roles.indexOf(data.role) !== -1) {
                         let _roles = removeItemAll(member.roles, [data.role]);
-                        discordClient.editGuildMember(data.server, member.id, {roles: _roles,}, "User Removed Permission (Open Access)")
+                        discordClient.editGuildMember(member.guild.id, member.id, {roles: _roles,}, "User Removed Permission (Open Access)")
                             .then(() => {
                                 SendMessage(`🔓 User ${(member.nick) ? member.nick : member.user.username} from ${member.guild.name} revoked ${(data.text) ? data.text : data.role} permission`, "info", 'main', "UserRightsMgr")
                             })

--- a/js/authware.js
+++ b/js/authware.js
@@ -33,21 +33,6 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
     const minimist = require("minimist");
     let args = minimist(process.argv.slice(2));
     let tfa = require('2fa');
-    const fs = require('fs');
-    String.prototype.toHex = function() {
-        var hash = 0;
-        if (this.length === 0) return hash;
-        for (var i = 0; i < this.length; i++) {
-            hash = this.charCodeAt(i) + ((hash << 5) - hash);
-            hash = hash & hash;
-        }
-        var color = '#';
-        for (var i = 0; i < 3; i++) {
-            var value = (hash >> (i * 8)) & 255;
-            color += ('00' + value.toString(16)).substr(-2);
-        }
-        return color;
-    }
 
     let authorizedUsers = new Map();
     let sudoUsers = new Map();
@@ -578,7 +563,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 let roleText = role.text.trim();
                 let color = null;
                 if (role.color !== null && role.color !== "0") {
-                    color = role.color.toHex();
+                    color = role.toString(16);
                 }
                 if (role.name.includes('_read')) {
                     type = 1

--- a/js/authware.js
+++ b/js/authware.js
@@ -557,14 +557,13 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
             }
         }))
     }
-    async function reactionAdded(partialMsg, emoji, user) {
-        if (reactionmessages.indexOf(partialMsg.id) !== -1) {
-            const msg = await discordClient.getMessage(partialMsg.channel.id, partialMsg.id);
+    async function reactionAdded(msg, emoji, user) {
+        if (reactionmessages.indexOf(msg.id) !== -1) {
             const userID = (user.id) ? user.id : user
             const data = discordreactionsroles[reactionmessages.indexOf(msg.id)];
-            if (data.emoji === emoji.name && data.server === msg.guild.id) {
+            if (data.emoji === emoji.name && data.server === msg.guildID) {
                 try {
-                    const member = await discordClient.getRESTGuildMember(msg.guild.id, userID);
+                    const member = await discordClient.getRESTGuildMember(msg.guildID, userID);
                     if (member.roles.indexOf(data.role) === -1) {
                         if (data.approval === 1) {
                             try {
@@ -572,7 +571,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                                 if (reqMsg && reqMsg.id) {
                                     pendingRequests.set(reqMsg.id, {
                                         data,
-                                        server: msg.guild.id,
+                                        server: msg.guildID,
                                         user: userID
                                     })
                                     await discordClient.addMessageReaction(reqMsg.channel.id, reqMsg.id, '✅');
@@ -593,8 +592,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                     Logger.printLine("UserRightsMgr", `Error when trying to get user data for ${userID}`, "error", e)
                 }
             }
-        } else if (pendingRequests.has(partialMsg.id)) {
-            const msg = await discordClient.getMessage(partialMsg.channel.id, partialMsg.id);
+        } else if (pendingRequests.has(msg.id)) {
             const req = pendingRequests.get(msg.id);
             const data = req.data;
             if (emoji.name === '✅') {
@@ -626,8 +624,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         if (reactionmessages.indexOf(msg.id) !== -1) {
             const userID = (user.id) ? user.id : user
             const data = discordreactionsroles[reactionmessages.indexOf(msg.id)];
-            if (data.emoji === emoji.name && data.server === msg.guild.id) {
-                const member = await discordClient.getRESTGuildMember(msg.guild.id, userID);
+            if (data.emoji === emoji.name && data.server === msg.guildID) {
+                const member = await discordClient.getRESTGuildMember(msg.guildID, userID);
                 if (member.roles.indexOf(data.role) !== -1) {
                     let _roles = removeItemAll(member.roles, [data.role]);
                     discordClient.editGuildMember(data.server, member.id, { roles: _roles, }, "User Removed Permission (Open Access)")

--- a/js/authware.js
+++ b/js/authware.js
@@ -755,7 +755,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 let token1 = crypto.randomBytes(512).toString("hex");
                 let token2 = crypto.randomBytes(128).toString("hex");
 
-                if (expires <= now) {
+                if (expires <= now || !user) {
                     const updatedUser = await db.query('INSERT INTO discord_users_extended SET id = ?, token = ?, blind_token = ?, token_expires = ? ON DUPLICATE KEY UPDATE token = ?, blind_token = ?, token_expires = ?', [userId.id, token1, token2, next_expires, token1, token2, next_expires])
                     if (updatedUser.error)
                         SendMessage("SQL Error occurred when updating user token", "err", 'main', "SQL", updatedUser.error)

--- a/js/authware.js
+++ b/js/authware.js
@@ -962,8 +962,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 user: {
                     id: userId,
                     username: (users[0].nice_name) ? users[0].nice_name : users[0].username,
-                    avatar: (users[0].avatar) ? `https://cdn.discordapp.com/avatars/${userId}/${users[0].avatar}.${(users[0].avatar && users[0].avatar.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : `https://cdn.discordapp.com/embed/avatars/0.png?size=4096`,
-                    banner: (users[0].banner) ? `https://cdn.discordapp.com/banners/${userId}/${users[0].banner}.${(users[0].banner && users[0].banner.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : undefined
+                    avatar: (users[0].avatar_custom) ? `https://cdn.discordapp.com/attachments/${users[0].avatar_custom}?size=4096` : (users[0].avatar) ? `https://cdn.discordapp.com/avatars/${userId}/${users[0].avatar}.${(users[0].avatar && users[0].avatar.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : `https://cdn.discordapp.com/embed/avatars/0.png?size=4096`,
+                    banner: (users[0].banner_custom) ? `https://cdn.discordapp.com/attachments/${users[0].banner_custom}?size=4096` : (users[0].banner) ? `https://cdn.discordapp.com/banners/${userId}/${users[0].banner}.${(users[0].banner && users[0].banner.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : undefined
                 },
                 server_list: [],
                 cache: {

--- a/js/authware.js
+++ b/js/authware.js
@@ -402,7 +402,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         discordClient.registerCommand("sudo", async function (msg,args) {
             if (isAuthorizedUser('elevateAllowed', msg.member.id, msg.member.guild.id, msg.channel.id)) {
                 const perms = await db.query(`SELECT role, server FROM discord_permissons WHERE name = 'syselevated'`);
-                const users = await db.query(`SELECT 2fa_key FROM discord_users WHERE id = ? AND server = ? ORDER BY 2fa_key`, [msg.member.id, msg.member.guild.id]);
+                const users = await db.query(`SELECT 2fa_key FROM discord_users WHERE id = ? ORDER BY 2fa_key`, [msg.member.id]);
 
                 if (perms.error) { return "SQL Error occurred when retrieving the user permissions data" }
                 if (users.error) { return "SQL Error occurred when retrieving the user data" }
@@ -486,7 +486,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         })
         discordClient.registerCommand("2fa", async function (msg,args) {
             if (isAuthorizedUser('elevateAllowed', msg.member.id, msg.member.guild.id, msg.channel.id)) {
-                const users = await db.query(`SELECT 2fa_key FROM discord_users WHERE id = ? AND server = ? ORDER BY 2fa_key`, [msg.member.id, msg.member.guild.id]);
+                const users = await db.query(`SELECT 2fa_key FROM discord_users WHERE id = ? ORDER BY 2fa_key`, [msg.member.id]);
                 if (users.error) { return "SQL Error occurred when retrieving the user data" }
 
                 const twofakey = users.rows.filter(e => e['2fa_key'] !== null).map(e => e['2fa_key']);
@@ -502,7 +502,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                                         file: Buffer.from(qr.replace('data:image/png;base64,', ''), 'base64')
                                     })
                                         .then(async completed => {
-                                            const addkey = await db.query(`UPDATE discord_users SET 2fa_key = ? WHERE id = ? AND server = ?`,[key, msg.member.id, msg.member.guild.id]);
+                                            const addkey = await db.query(`UPDATE discord_users SET 2fa_key = ? WHERE id = ?`,[key, msg.member.id]);
                                             if (addkey.error) { SendMessage("❌ Failed to save 2FA key to user account, disregard last message", msg.channel.id, msg.member.guild.id, "SystemMgr"); }
                                         })
                                         .catch(err => {

--- a/js/authware.js
+++ b/js/authware.js
@@ -115,6 +115,11 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                     }
                 }
             }
+            const _seq_config = systemparams_sql.filter(e => e.param_key === 'seq.common');
+            if (_seq_config.length > 0 && _seq_config[0].param_data) {
+                if (_seq_config[0].param_data.user_card_membership)
+                    systemglobal.user_card_membership = _seq_config[0].param_data.user_card_membership;
+            }
         }
 
         Logger.printLine("SQL", "Getting Discord Servers", "debug")
@@ -957,8 +962,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 blind_token_expires: users[0].token_expires,
             };
 
-            if (webconfig.user_card_membership) {
-                const _ms = await webconfig.user_card_membership.filter(m => (readPermissions.indexOf(m.role) !== -1 || writePermissions.indexOf(m.role) !== -1 || specialPermissions.indexOf(m.role) !== -1)).map(e => {
+            if (systemglobal.user_card_membership) {
+                const _ms = await systemglobal.user_card_membership.filter(m => (readPermissions.indexOf(m.role) !== -1 || writePermissions.indexOf(m.role) !== -1 || specialPermissions.indexOf(m.role) !== -1)).map(e => {
                     return {
                         text: (e.text) ? e.text : (readPermissions.indexOf(e.role) !== -1 && readPermissionsRows[readPermissions.indexOf(e.role)].text) ? readPermissionsRows[readPermissions.indexOf(e.role)].text : (writePermissions.indexOf(e.role) !== -1 && writePermissionsRows[writePermissions.indexOf(e.role)].text) ? writePermissionsRows[writePermissions.indexOf(e.role)].text : (specialPermissions.indexOf(e.role) !== -1 && specialPermissionsRows[specialPermissions.indexOf(e.role)].text) ? specialPermissionsRows[specialPermissions.indexOf(e.role)].text : undefined,
                         background: (e.background) ? e.background : (readPermissions.indexOf(e.role) !== -1 && readPermissionsRows[readPermissions.indexOf(e.role)].color) ? readPermissionsRows[readPermissions.indexOf(e.role)].color : (writePermissions.indexOf(e.role) !== -1 && writePermissionsRows[writePermissions.indexOf(e.role)].color) ? writePermissionsRows[writePermissions.indexOf(e.role)].color : (specialPermissions.indexOf(e.role) !== -1 && specialPermissionsRows[specialPermissions.indexOf(e.role)].color) ? specialPermissionsRows[specialPermissions.indexOf(e.role)].color : undefined,

--- a/js/authware.js
+++ b/js/authware.js
@@ -557,8 +557,9 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
             }
         }))
     }
-    async function reactionAdded(msg, emoji, user) {
-        if (reactionmessages.indexOf(msg.id) !== -1) {
+    async function reactionAdded(partialMsg, emoji, user) {
+        if (reactionmessages.indexOf(partialMsg.id) !== -1) {
+            const msg = await discordClient.getMessage(partialMsg.channel.id, partialMsg.id);
             const userID = (user.id) ? user.id : user
             const data = discordreactionsroles[reactionmessages.indexOf(msg.id)];
             if (data.emoji === emoji.name && data.server === msg.guild.id) {
@@ -592,7 +593,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                     Logger.printLine("UserRightsMgr", `Error when trying to get user data for ${userID}`, "error", e)
                 }
             }
-        } else if (pendingRequests.has(msg.id)) {
+        } else if (pendingRequests.has(partialMsg.id)) {
+            const msg = await discordClient.getMessage(partialMsg.channel.id, partialMsg.id);
             const req = pendingRequests.get(msg.id);
             const data = req.data;
             if (emoji.name === '✅') {

--- a/js/authware.js
+++ b/js/authware.js
@@ -914,7 +914,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
             let userAccount = {
                 discord: {
                     user: {
-                        id,
+                        userId,
                         server: _server_list.filter(e => e.serverid === users[0].server),
                         name: users[0].nice_name,
                         username: users[0].username,

--- a/js/authware.js
+++ b/js/authware.js
@@ -706,6 +706,10 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 const member = guild.members.get(memberID)
                 await memberRoleGeneration(guild, member);
             }))
+            await Promise.all(Array.from(guild.roles.keys()).map(async (roleID) => {
+                const role = guild.roles.get(roleID)
+                await guildRoleCreate(guild, role);
+            }))
         }))
         await updateLocalCache();
     });

--- a/js/authware.js
+++ b/js/authware.js
@@ -561,9 +561,9 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         if (reactionmessages.indexOf(msg.id) !== -1) {
             const userID = (user.id) ? user.id : user
             const data = discordreactionsroles[reactionmessages.indexOf(msg.id)];
-            if (data.emoji === emoji.name && data.server === msg.server.id) {
+            if (data.emoji === emoji.name && data.server === msg.guild.id) {
                 try {
-                    const member = await discordClient.getRESTGuildMember(msg.server.id, userID);
+                    const member = await discordClient.getRESTGuildMember(msg.guild.id, userID);
                     if (member.roles.indexOf(data.role) === -1) {
                         if (data.approval === 1) {
                             try {
@@ -571,7 +571,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                                 if (reqMsg && reqMsg.id) {
                                     pendingRequests.set(reqMsg.id, {
                                         data,
-                                        server: msg.server.id,
+                                        server: msg.guild.id,
                                         user: userID
                                     })
                                     await discordClient.addMessageReaction(reqMsg.channel.id, reqMsg.id, '✅');
@@ -624,8 +624,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         if (reactionmessages.indexOf(msg.id) !== -1) {
             const userID = (user.id) ? user.id : user
             const data = discordreactionsroles[reactionmessages.indexOf(msg.id)];
-            if (data.emoji === emoji.name && data.server === msg.server.id) {
-                const member = await discordClient.getRESTGuildMember(msg.server.id, userID);
+            if (data.emoji === emoji.name && data.server === msg.guild.id) {
+                const member = await discordClient.getRESTGuildMember(msg.guild.id, userID);
                 if (member.roles.indexOf(data.role) !== -1) {
                     let _roles = removeItemAll(member.roles, [data.role]);
                     discordClient.editGuildMember(data.server, member.id, { roles: _roles, }, "User Removed Permission (Open Access)")

--- a/js/authware.js
+++ b/js/authware.js
@@ -19,11 +19,6 @@ about release, "snippets", or to report spillage are to be directed to:
 (Academy City Research Document & Data Control Services)
 docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
 ====================================================================================== */
-
-import {resolve} from "path";
-import systemglobal from "../config.json";
-import md5 from "md5";
-
 (async () => {
     let systemglobal = require('../config.json');
     if (process.env.SYSTEM_NAME && process.env.SYSTEM_NAME.trim().length > 0)

--- a/js/authware.js
+++ b/js/authware.js
@@ -1263,7 +1263,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         });
 
         if (!thisUser) {
-            sequenziaAccountUpdateTimer = setTimeout(sequenziaUserCacheGenerator, (thisUser) ? 900000 : 1500000);
+            sequenziaAccountUpdateTimer = setTimeout(sequenziaUserCacheGenerator, 300000);
         }
     }
 

--- a/js/authware.js
+++ b/js/authware.js
@@ -119,6 +119,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
             if (_seq_config.length > 0 && _seq_config[0].param_data) {
                 if (_seq_config[0].param_data.user_card_membership)
                     systemglobal.user_card_membership = _seq_config[0].param_data.user_card_membership;
+                if (_seq_config[0].param_data.web_applications)
+                    systemglobal.web_applications = _seq_config[0].param_data.web_applications;
             }
         }
 

--- a/js/authware.js
+++ b/js/authware.js
@@ -858,124 +858,124 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         })
 
         allUserIds.filter(f => !thisUser || (thisUser && f === thisUser)).map(async userId => {
-            await new Promise(async (resolve) => {
-                const sidebarViewsqlFields = [
-                    `kanmi_auth_${userId}.channelid`,
-                    `kanmi_auth_${userId}.channel_eid`,
-                    `kanmi_auth_${userId}.virtual_channel_eid`,
-                    'discord_servers.serverid',
-                    `kanmi_auth_${userId}.position`,
-                    'sequenzia_superclass.position AS super_position',
-                    'sequenzia_superclass.super',
-                    'sequenzia_superclass.name AS super_name',
-                    'sequenzia_superclass.icon AS super_icon',
-                    'sequenzia_superclass.uri AS super_uri',
-                    'sequenzia_class.uri AS class_uri',
-                    'sequenzia_class.position AS class_position',
-                    'sequenzia_class.class',
-                    'sequenzia_class.name AS class_name',
-                    'sequenzia_class.icon AS class_icon',
-                    `kanmi_auth_${userId}.channel_nsfw`,
-                    `kanmi_auth_${userId}.channel_name`,
-                    `kanmi_auth_${userId}.channel_image`,
-                    `kanmi_auth_${userId}.channel_title`,
-                    `kanmi_auth_${userId}.channel_short_name`,
-                    `kanmi_auth_${userId}.channel_nice`,
-                    `kanmi_auth_${userId}.channel_description`,
-                    `kanmi_auth_${userId}.channel_uri`,
-                    `discord_servers.position AS server_position`,
-                    'discord_servers.name AS server_name',
-                    'discord_servers.nice_name AS server_nice',
-                    'discord_servers.short_name AS server_short',
-                    'discord_servers.avatar AS server_avatar',
-                    `kanmi_auth_${userId}.role_write`,
-                    `kanmi_auth_${userId}.role_manage`,
-                ].join(', ');
-                const sidebarViewsqlTables = [
-                    'discord_servers',
-                    'sequenzia_superclass',
-                    'sequenzia_class',
-                    `kanmi_auth_${userId}`,
-                ].join(', ');
-                const sidebarViewsqlWhere = [
-                    `kanmi_auth_${userId}.classification IS NOT NULL`,
-                    `kanmi_auth_${userId}.classification = sequenzia_class.class`,
-                    `kanmi_auth_${userId}.serverid = discord_servers.serverid`,
-                    'sequenzia_class.class IS NOT NULL',
-                    'sequenzia_class.super = sequenzia_superclass.super',
-                ].join(' AND ');
+            const sidebarViewsqlFields = [
+                `kanmi_auth_${userId}.channelid`,
+                `kanmi_auth_${userId}.channel_eid`,
+                `kanmi_auth_${userId}.virtual_channel_eid`,
+                'discord_servers.serverid',
+                `kanmi_auth_${userId}.position`,
+                'sequenzia_superclass.position AS super_position',
+                'sequenzia_superclass.super',
+                'sequenzia_superclass.name AS super_name',
+                'sequenzia_superclass.icon AS super_icon',
+                'sequenzia_superclass.uri AS super_uri',
+                'sequenzia_class.uri AS class_uri',
+                'sequenzia_class.position AS class_position',
+                'sequenzia_class.class',
+                'sequenzia_class.name AS class_name',
+                'sequenzia_class.icon AS class_icon',
+                `kanmi_auth_${userId}.channel_nsfw`,
+                `kanmi_auth_${userId}.channel_name`,
+                `kanmi_auth_${userId}.channel_image`,
+                `kanmi_auth_${userId}.channel_title`,
+                `kanmi_auth_${userId}.channel_short_name`,
+                `kanmi_auth_${userId}.channel_nice`,
+                `kanmi_auth_${userId}.channel_description`,
+                `kanmi_auth_${userId}.channel_uri`,
+                `discord_servers.position AS server_position`,
+                'discord_servers.name AS server_name',
+                'discord_servers.nice_name AS server_nice',
+                'discord_servers.short_name AS server_short',
+                'discord_servers.avatar AS server_avatar',
+                `kanmi_auth_${userId}.role_write`,
+                `kanmi_auth_${userId}.role_manage`,
+            ].join(', ');
+            const sidebarViewsqlTables = [
+                'discord_servers',
+                'sequenzia_superclass',
+                'sequenzia_class',
+                `kanmi_auth_${userId}`,
+            ].join(', ');
+            const sidebarViewsqlWhere = [
+                `kanmi_auth_${userId}.classification IS NOT NULL`,
+                `kanmi_auth_${userId}.classification = sequenzia_class.class`,
+                `kanmi_auth_${userId}.serverid = discord_servers.serverid`,
+                'sequenzia_class.class IS NOT NULL',
+                'sequenzia_class.super = sequenzia_superclass.super',
+            ].join(' AND ');
 
-                const users = allUsers.filter(e => userId === e.id);
-                const userPermissions = allDisabledChannels.filter(e => e.userid === userId);
-                const disabledChannels = allUserPermissions.filter(e => e.user === userId);
+            const users = allUsers.filter(e => userId === e.id);
+            const userPermissions = allDisabledChannels.filter(e => e.userid === userId);
+            const disabledChannels = allUserPermissions.filter(e => e.user === userId);
 
-                const readPermissionsRows = userPermissions.filter(e => e.type === 1);
-                const writePermissionsRows = userPermissions.filter(e => e.type === 2);
-                const managePermissionsRows = userPermissions.filter(e => e.type === 3);
-                const specialPermissionsRows = userPermissions.filter(e => e.type === 4);
+            const readPermissionsRows = userPermissions.filter(e => e.type === 1);
+            const writePermissionsRows = userPermissions.filter(e => e.type === 2);
+            const managePermissionsRows = userPermissions.filter(e => e.type === 3);
+            const specialPermissionsRows = userPermissions.filter(e => e.type === 4);
 
-                const readPermissions = readPermissionsRows.map(e => e.role);
-                const writePermissions = writePermissionsRows.map(e => e.role);
-                const managePermissions = managePermissionsRows.map(e => e.role);
-                const specialPermissions = specialPermissionsRows.map(e => e.role);
+            const readPermissions = readPermissionsRows.map(e => e.role);
+            const writePermissions = writePermissionsRows.map(e => e.role);
+            const managePermissions = managePermissionsRows.map(e => e.role);
+            const specialPermissions = specialPermissionsRows.map(e => e.role);
 
-                let userAccount = {
-                    discord: {
-                        user: {
-                            userId,
-                            server: _server_list.filter(e => e.serverid === users[0].server),
-                            name: users[0].nice_name,
-                            username: users[0].username,
-                            avatar: users[0].avatar,
-                            banner: users[0].banner,
-                            known: true,
-                            membership: {
-                                text: 'Member'
-                            },
-                            auth_token: null,
-                            token: users[0].token,
-                            token_login: users[0].blind_token,
-                            token_static: users[0].token_static,
-                            token_rotation: users[0].token_expires
+            let userAccount = {
+                discord: {
+                    user: {
+                        userId,
+                        server: _server_list.filter(e => e.serverid === users[0].server),
+                        name: users[0].nice_name,
+                        username: users[0].username,
+                        avatar: users[0].avatar,
+                        banner: users[0].banner,
+                        known: true,
+                        membership: {
+                            text: 'Member'
                         },
-                        permissions: {
-                            read: readPermissions,
-                            write: writePermissions,
-                            manage: managePermissions,
-                            specialPermissions: specialPermissions
-                        },
-                        channels: {
-                            read: [],
-                            write: [],
-                            manage: [],
-                        },
-                        servers: {
-                            download: [],
-                            list: _server_list
-                        },
-                        links: homeLinks
+                        auth_token: null,
+                        token: users[0].token,
+                        token_login: users[0].blind_token,
+                        token_static: users[0].token_static,
+                        token_rotation: users[0].token_expires
                     },
-                    server_list: [],
-                    cache: {
-                        channels_view: `kanmi_auth_${userId}`,
-                        sidebar_view: `kanmi_sidebar_${userId}`
+                    permissions: {
+                        read: readPermissions,
+                        write: writePermissions,
+                        manage: managePermissions,
+                        specialPermissions: specialPermissions
                     },
-                    sidebar: [],
-                    albums: [],
-                    artists: [],
-                    media_groups: [],
-                    applications_list: [],
-                    kongou_next_episode: {},
-                    disabled_channels: (disabledChannels) ? disabledChannels.map(e => e.cid) : [],
-                    blind_token_expires: users[0].token_expires,
-                };
-                userAccount.user = {
+                    channels: {
+                        read: [],
+                        write: [],
+                        manage: [],
+                    },
+                    servers: {
+                        download: [],
+                        list: _server_list
+                    },
+                    links: homeLinks
+                },
+                user: {
                     id: userId,
                     username: (userAccount.discord.user.name) ? userAccount.discord.user.name : userAccount.discord.user.username,
                     avatar: (users[0].avatar) ? `https://cdn.discordapp.com/avatars/${userId}/${users[0].avatar}.${(users[0].avatar && users[0].avatar.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : `https://cdn.discordapp.com/embed/avatars/0.png?size=4096`,
                     banner: (users[0].banner) ? `https://cdn.discordapp.com/banners/${userId}/${users[0].banner}.${(users[0].banner && users[0].banner.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : undefined
-                }
+                },
+                server_list: [],
+                cache: {
+                    channels_view: `kanmi_auth_${userId}`,
+                    sidebar_view: `kanmi_sidebar_${userId}`
+                },
+                sidebar: [],
+                albums: [],
+                artists: [],
+                media_groups: [],
+                applications_list: [],
+                kongou_next_episode: {},
+                disabled_channels: (disabledChannels) ? disabledChannels.map(e => e.cid) : [],
+                time_generated: (new Date().valueOf()).toString(),
+            };
 
+            await new Promise(async (resolve) => {
                 if (systemglobal.user_card_membership) {
                     const _ms = await systemglobal.user_card_membership.filter(m => (readPermissions.indexOf(m.role) !== -1 || writePermissions.indexOf(m.role) !== -1 || specialPermissions.indexOf(m.role) !== -1)).map(e => {
                         return {

--- a/js/authware.js
+++ b/js/authware.js
@@ -574,6 +574,9 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                     type = 0
                 }
                 await db.query(`INSERT INTO discord_users_permissons SET userid = ?, serverid = ?, role = ?, type = ?`, [member.user.id, guild.id, roleName, type]);
+                if (roleName === 'user') {
+                    await db.query(`INSERT INTO discord_users_permissons SET userid = ?, serverid = ?, role = ?, type = ?`, [member.user.id, guild.id, `${roleName}-${guild.id}`, type]);
+                }
             }
         }
         const userRole = serverPermissions.rows.filter(e => e.name && e.name === 'system_user').map(e => e.role)

--- a/js/authware.js
+++ b/js/authware.js
@@ -638,11 +638,14 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         }
     }
     async function guildRoleCreate(guild, role) {
-        if (discordperms.filter(e => e.role === role.id).length === 0) {
-            const addedRole = await db.query('INSERT INTO discord_permissons SET role = ?, server = ?, color = ?, name = NULL ON DUPLICATE KEY UPDATE color = ?', [role.id, guild.id, role.color, role.color])
-            if (addedRole.error)
-                SendMessage("SQL Error occurred when saving new role", "err", 'main', "SQL", addedRole.error)
-        }
+        const addedRole = await db.query('INSERT INTO discord_permissons SET ? ON DUPLICATE KEY UPDATE color = ?', [{
+            role: role.id,
+            server: guild.id,
+            color: role.color,
+            name: null
+        }, role.color])
+        if (addedRole.error)
+            SendMessage("SQL Error occurred when saving new role", "err", 'main', "SQL", addedRole.error)
     }
     async function guildRoleDelete(role) {
         const deletedRole = await db.query('DELETE FROM discord_permissons WHERE role = ?', [role.id])

--- a/js/authware.js
+++ b/js/authware.js
@@ -897,7 +897,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 'sequenzia_class.super = sequenzia_superclass.super',
             ].join(' AND ');
 
-            const users = allUsers.filter(e => userId === e.id)[0];
+            const users = allUsers.filter(e => userId === e.id);
             const userPermissions = allDisabledChannels.filter(e => e.userid === userId);
             const disabledChannels = allUserPermissions.filter(e => e.user === userId);
 

--- a/js/authware.js
+++ b/js/authware.js
@@ -639,7 +639,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
     }
     async function guildRoleCreate(guild, role) {
         if (discordperms.filter(e => e.role === role.id).length === 0) {
-            const addedRole = await db.query('INSERT INTO discord_permissons SET role = ?, server = ?, color = ?, name = NULL ON DUPLICATE KEY UPDATE color = ?', [role.id, role.color, guild.id, role.color])
+            const addedRole = await db.query('INSERT INTO discord_permissons SET role = ?, server = ?, color = ?, name = NULL ON DUPLICATE KEY UPDATE color = ?', [role.id, guild.id, role.color, role.color])
             if (addedRole.error)
                 SendMessage("SQL Error occurred when saving new role", "err", 'main', "SQL", addedRole.error)
         }

--- a/js/authware.js
+++ b/js/authware.js
@@ -563,7 +563,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 let roleText = role.text.trim();
                 let color = null;
                 if (role.color !== null && role.color !== "0") {
-                    color = role.toString(16);
+                    color = "#" + Number(parseInt(role.color)).toString(16).padStart(2, '0')
                 }
                 if (role.name.includes('_read')) {
                     type = 1

--- a/js/authware.js
+++ b/js/authware.js
@@ -621,6 +621,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 } else if (emoji.name === '❌') {
                     await discordClient.deleteMessage(msg.channel.id, msg.id, "Declined Request")
                 }
+                pendingRequests.delete(msg.id)
             }
         }
     }

--- a/js/authware.js
+++ b/js/authware.js
@@ -603,7 +603,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                         _roles.push(data.role);
                         discordClient.editGuildMember(req.server, member.id, { roles: _roles, }, "User Granted Permission (Open Access)")
                             .then(async () => {
-                                SendMessage(`🔓 User ${(member.nick) ? member.nick : member.user.username} from ${member.guild.name} was granted ${(data.name) ? data.name : data.role} permission`, "info", 'main', "UserRightsMgr")
+                                SendMessage(`🔓 User ${(member.nick) ? member.nick : member.user.username} from ${member.guild.name} was granted ${(data.name) ? data.name : data.role} permission`, "info", 'main', "UserRightsMgr");
+                                await discordClient.deleteMessage(msg.channel.id, msg.id, "Approved Request")
                                 const userDirect = await discordClient.getRESTUser(member.id)
                                 if (userDirect) {
                                     userDirect.getDMChannel().then(channel => {
@@ -613,6 +614,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                                             });
                                     });
                                 }
+
                             })
                             .catch((er) => { Logger.printLine("UserRightsMgr", `Error when trying to grant user rights to ${(member.nick) ? member.nick : member.user.username} from ${member.guild.name}`, "error", er) })
                     }

--- a/js/authware.js
+++ b/js/authware.js
@@ -575,6 +575,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
             for (const role of serverPermissions.rows.filter(e => e.name && member.roles.indexOf(e.role) !== -1 && ignoredPermissions.indexOf(e.name) === -1)) {
                 let type = null;
                 let roleName = role.name.trim();
+                let roleText = role.text.trim();
                 let color = null;
                 if (role.color !== null && role.color !== "0") {
                     color = role.color.toHex();
@@ -591,9 +592,9 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 } else {
                     type = 0
                 }
-                await db.query(`INSERT INTO discord_users_permissons SET userid = ?, serverid = ?, color = ?, role = ?, type = ?`, [member.user.id, guild.id, color, roleName, type]);
+                await db.query(`INSERT INTO discord_users_permissons SET userid = ?, serverid = ?, color = ?, text = ?, role = ?, type = ?`, [member.user.id, guild.id, color, roleText, roleName, type]);
                 if (roleName === 'user') {
-                    await db.query(`INSERT INTO discord_users_permissons SET userid = ?, serverid = ?, color = ?, role = ?, type = ?`, [member.user.id, guild.id, color, `${roleName}-${guild.id}`, type]);
+                    await db.query(`INSERT INTO discord_users_permissons SET userid = ?, serverid = ?, color = ?, text = ?, role = ?, type = ?`, [member.user.id, guild.id, color, roleText, `${roleName}-${guild.id}`, type]);
                 }
             }
         }
@@ -656,12 +657,16 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         }
     }
     async function guildRoleCreate(guild, role) {
-        const addedRole = await db.query('INSERT INTO discord_permissons SET ? ON DUPLICATE KEY UPDATE color = ?', [{
+        const addedRole = await db.query('INSERT INTO discord_permissons SET ? ON DUPLICATE KEY UPDATE ?', [{
             role: role.id,
             server: guild.id,
             color: role.color,
+            text: role.name,
             name: null
-        }, role.color])
+        }, {
+            color: role.color,
+            text: role.name
+        }])
         if (addedRole.error)
             SendMessage("SQL Error occurred when saving new role", "err", 'main', "SQL", addedRole.error)
     }

--- a/js/authware.js
+++ b/js/authware.js
@@ -961,6 +961,12 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 disabled_channels: (disabledChannels) ? disabledChannels.map(e => e.cid) : [],
                 blind_token_expires: users[0].token_expires,
             };
+            userAccount.user = {
+                id: userAccount.discord.user.id,
+                username: (userAccount.discord.user.name) ? userAccount.discord.user.name : userAccount.discord.user.username,
+                avatar: (userAccount.discord.user.avatar) ? `https://cdn.discordapp.com/avatars/${userAccount.discord.user.id}/${userAccount.discord.user.avatar}.${(userAccount.discord.user.avatar && userAccount.discord.user.avatar.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : `https://cdn.discordapp.com/embed/avatars/0.png?size=4096`,
+                banner: (userAccount.discord.user.banner) ? `https://cdn.discordapp.com/banners/${userAccount.discord.user.id}/${userAccount.discord.user.banner}.${(userAccount.discord.user.banner && userAccount.discord.user.banner.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : undefined
+            }
 
             if (systemglobal.user_card_membership) {
                 const _ms = await systemglobal.user_card_membership.filter(m => (readPermissions.indexOf(m.role) !== -1 || writePermissions.indexOf(m.role) !== -1 || specialPermissions.indexOf(m.role) !== -1)).map(e => {
@@ -1001,7 +1007,6 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
 
             if (tempLastEpisode.rows.length > 0) {
                 const nextEpisodeView = await db.query(`SELECT * FROM  (SELECT * FROM kanmi_system.kongou_episodes WHERE eid > ${tempLastEpisode.rows[0].eid} AND show_id = ${tempLastEpisode.rows[0].show_id} AND season_num > 0 ORDER BY season_num ASC, episode_num ASC LIMIT 1) x LEFT JOIN (SELECT * FROM kanmi_system.kongou_shows) y ON (x.show_id = y.show_id);`)
-                console.log(nextEpisodeView.rows)
                 userAccount.kongou_next_episode = nextEpisodeView.rows[0];
             }
 

--- a/js/authware.js
+++ b/js/authware.js
@@ -833,8 +833,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
         ].join(', ');
 
 
-        const allUsers = (await db.query("SELECT x.*, y.authware_enabled, y.position FROM (SELECT x.serveruserid, x.server, x.username, x.avatar, x.banner, x.color, x.`2fa_key`, y.* FROM (SELECT serveruserid, id, server, username, avatar, banner, color, `2fa_key` FROM discord_users) x LEFT JOIN (SELECT * FROM discord_users_extended) y ON (x.id = y.id)) x LEFT JOIN (SELECT discord_servers.position, discord_servers.authware_enabled, discord_servers.name, discord_servers.serverid FROM discord_servers) y ON x.server = y.serverid ORDER BY y.authware_enabled, y.position, x.id")).rows
-        const allUserIds = [...new Set(allUsers.map(e => e.id))];
+        const allUsers = (await db.query("SELECT x.* FROM (SELECT x.serveruserid, x.server, x.username, x.avatar, x.banner, x.color, x.`2fa_key`, y.* FROM (SELECT serveruserid, id, server, username, avatar, banner, color, `2fa_key` FROM discord_users) x LEFT JOIN (SELECT * FROM discord_users_extended) y ON (x.id = y.id)) x LEFT JOIN (SELECT discord_servers.position, discord_servers.authware_enabled, discord_servers.name, discord_servers.serverid FROM discord_servers) y ON x.server = y.serverid ORDER BY y.authware_enabled, y.position, x.id")).rows
+        const allUserIds = [...new Set(allUsers.filter(e => !!e.id).map(e => e.id))];
         const extraLinks = (await db.query(`SELECT * FROM sequenzia_homelinks ORDER BY position`)).rows
         const allUserPermissions = (await db.query("SELECT DISTINCT role, type, userid, color, text, serverid FROM discord_users_permissons")).rows
         const allChannels = (await db.query("SELECT x.*, y.chid_download FROM ( SELECT DISTINCT kanmi_channels.channelid, kanmi_channels.serverid, kanmi_channels.role, kanmi_channels.role_write, kanmi_channels.role_manage FROM kanmi_channels, sequenzia_class WHERE kanmi_channels.role IS NOT NULL AND kanmi_channels.classification = sequenzia_class.class) x LEFT OUTER JOIN (SELECT chid_download, serverid FROM discord_servers) y ON (x.serverid = y.serverid AND x.channelid = y.chid_download)")).rows;

--- a/js/authware.js
+++ b/js/authware.js
@@ -905,8 +905,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
             ].join(' AND ');
 
             const users = allUsers.filter(e => userId === e.id);
-            const userPermissions = allDisabledChannels.filter(e => e.userid === userId);
-            const disabledChannels = allUserPermissions.filter(e => e.user === userId);
+            const userPermissions = allUserPermissions.filter(e => e.userid === userId);
+            const disabledChannels = allDisabledChannels.filter(e => e.user === userId);
 
             const readPermissionsRows = userPermissions.filter(e => e.type === 1);
             const writePermissionsRows = userPermissions.filter(e => e.type === 2);
@@ -992,7 +992,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                     }
                 }
 
-                await allChannels.forEach(u => {
+                allChannels.map(u => {
                     if (readPermissions.indexOf(u.role) !== -1 || specialPermissions.indexOf(u.role) !== -1)
                         userAccount.discord.channels.read.push(u.channelid)
                     if (writePermissions.indexOf(u.role_write) !== -1 || managePermissions.indexOf(u.role_write) !== -1 || specialPermissions.indexOf(u.role_write) !== -1) {
@@ -1127,13 +1127,13 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                         return distinct
                     })(sidebarObject.rows)
 
-                    superClasses.forEach((thisSuper) => {
+                    superClasses.map((thisSuper) => {
                         let _items = []
-                        classes.filter(e => e.super === thisSuper.super ).forEach((thisClass) => {
+                        classes.filter(e => e.super === thisSuper.super ).map((thisClass) => {
                             const _channels = sidebarObject.rows.filter(e => e.class === thisClass.class && e.virtual_channel_eid === null).map((thisChannel) => {
                                 let channelName = ''
                                 if (thisChannel.channel_nice === null) {
-                                    thisChannel.channel_name.split('-').forEach((wd, i, a) => {
+                                    thisChannel.channel_name.split('-').map((wd, i, a) => {
                                         channelName += wd.substring(0, 1).toUpperCase() + wd.substring(1, wd.length)
                                         if (i + 1 < a.length) {
                                             channelName += ' '
@@ -1157,13 +1157,13 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                                 })
                             })
                             let _mergedChannels = [];
-                            virtualChannels.forEach((vcid) => {
+                            virtualChannels.map((vcid) => {
                                 let _vc_entities = [];
                                 let _vc_nsfw = false;
                                 sidebarObject.rows.filter(e => e.class === thisClass.class && vcid.class === thisClass.class && e.virtual_channel_eid !== null && e.virtual_channel_eid === vcid.id).map((thisChannel) => {
                                     let channelName = ''
                                     if (thisChannel.channel_nice === null) {
-                                        thisChannel.channel_name.split('-').forEach((wd, i, a) => {
+                                        thisChannel.channel_name.split('-').map((wd, i, a) => {
                                             channelName += wd.substring(0, 1).toUpperCase() + wd.substring(1, wd.length)
                                             if (i + 1 < a.length) {
                                                 channelName += ' '

--- a/js/authware.js
+++ b/js/authware.js
@@ -921,7 +921,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
             let userAccount = {
                 discord: {
                     user: {
-                        userId,
+                        id: userId,
                         server: _server_list.filter(e => e.serverid === users[0].server),
                         name: users[0].nice_name,
                         username: users[0].username,

--- a/js/authware.js
+++ b/js/authware.js
@@ -956,7 +956,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 },
                 user: {
                     id: userId,
-                    username: (userAccount.discord.user.name) ? userAccount.discord.user.name : userAccount.discord.user.username,
+                    username: (users[0].nice_name) ? users[0].nice_name : users[0].username,
                     avatar: (users[0].avatar) ? `https://cdn.discordapp.com/avatars/${userId}/${users[0].avatar}.${(users[0].avatar && users[0].avatar.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : `https://cdn.discordapp.com/embed/avatars/0.png?size=4096`,
                     banner: (users[0].banner) ? `https://cdn.discordapp.com/banners/${userId}/${users[0].banner}.${(users[0].banner && users[0].banner.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : undefined
                 },

--- a/js/authware.js
+++ b/js/authware.js
@@ -7,7 +7,7 @@
 Developed at Academy City Research
 "Developing a better automated future"
 ======================================================================================
-Kanmi Project - Discord I/O System
+Shutaura Project - Discord I/O System
 Copyright 2020
 ======================================================================================
 This code is under a strict NON-DISCLOSURE AGREEMENT, If you have the rights

--- a/js/authware.js
+++ b/js/authware.js
@@ -962,8 +962,8 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 user: {
                     id: userId,
                     username: (users[0].nice_name) ? users[0].nice_name : users[0].username,
-                    avatar: (users[0].avatar_custom) ? `https://cdn.discordapp.com/attachments/${users[0].avatar_custom}?size=4096` : (users[0].avatar) ? `https://cdn.discordapp.com/avatars/${userId}/${users[0].avatar}.${(users[0].avatar && users[0].avatar.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : `https://cdn.discordapp.com/embed/avatars/0.png?size=4096`,
-                    banner: (users[0].banner_custom) ? `https://cdn.discordapp.com/attachments/${users[0].banner_custom}?size=4096` : (users[0].banner) ? `https://cdn.discordapp.com/banners/${userId}/${users[0].banner}.${(users[0].banner && users[0].banner.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : undefined
+                    avatar: (users[0].avatar_custom) ? `https://cdn.discordapp.com/attachments${users[0].avatar_custom}?size=4096` : (users[0].avatar) ? `https://cdn.discordapp.com/avatars/${userId}/${users[0].avatar}.${(users[0].avatar && users[0].avatar.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : `https://cdn.discordapp.com/embed/avatars/0.png?size=4096`,
+                    banner: (users[0].banner_custom) ? `https://cdn.discordapp.com/attachments${users[0].banner_custom}?size=4096` : (users[0].banner) ? `https://cdn.discordapp.com/banners/${userId}/${users[0].banner}.${(users[0].banner && users[0].banner.startsWith('a_')) ? 'gif' : 'jpg'}?size=4096` : undefined
                 },
                 server_list: [],
                 cache: {

--- a/js/authware.js
+++ b/js/authware.js
@@ -639,7 +639,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
     }
     async function guildRoleCreate(guild, role) {
         if (discordperms.filter(e => e.role === role.id).length === 0) {
-            const addedRole = await db.query('INSERT INTO discord_permissons SET role = ?, server = ?, name = NULL', [role.id, guild.id])
+            const addedRole = await db.query('INSERT INTO discord_permissons SET role = ?, server = ?, color = ?, name = NULL ON DUPLICATE KEY UPDATE color = ?', [role.id, role.color, guild.id, role.color])
             if (addedRole.error)
                 SendMessage("SQL Error occurred when saving new role", "err", 'main', "SQL", addedRole.error)
         }

--- a/js/authware.js
+++ b/js/authware.js
@@ -33,6 +33,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
     const minimist = require("minimist");
     let args = minimist(process.argv.slice(2));
     let tfa = require('2fa');
+    const md5 = require("md5");
 
     let authorizedUsers = new Map();
     let sudoUsers = new Map();

--- a/js/authware.js
+++ b/js/authware.js
@@ -957,6 +957,11 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                     channels_view: `kanmi_auth_${userId}`,
                     sidebar_view: `kanmi_sidebar_${userId}`
                 },
+                sidebar: [],
+                albums: [],
+                artists: [],
+                media_groups: [],
+                applications_list: [],
                 kongou_next_episode: {},
                 disabled_channels: (disabledChannels) ? disabledChannels.map(e => e.cid) : [],
                 blind_token_expires: users[0].token_expires,
@@ -1017,6 +1022,235 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
                 short_name: e.server_short.toUpperCase(),
                 login: (e.authware_enabled)
             }));
+
+            if (systemglobal.web_applications) {
+                const perms = [
+                    ...userAccount.discord.permissions.read,
+                    ...userAccount.discord.permissions.write,
+                    ...userAccount.discord.permissions.manage,
+                    ...userAccount.discord.permissions.specialPermissions
+                ]
+                userAccount.applications_list.push(...Object.keys(systemglobal.web_applications).filter(k =>
+                    perms.filter(p => systemglobal.web_applications[k].read_roles.indexOf(p) !== -1).length > 0
+                ).map(k => {
+                    const app = systemglobal.web_applications[k];
+                    if (app.embedded) {
+                        let images = {}
+                        if (app.images) {
+                            const keys = Object.keys(app.images);
+                            keys.map(j => {
+                                images[j] = `/app/web/${k}/${app.images[j]}`
+                            })
+                        } else {
+                            images = undefined
+                        }
+                        return {
+                            type: 1,
+                            id: k,
+                            icon: app.icon,
+                            name: app.name,
+                            images
+                        }
+                    } else {
+                        return {
+                            type: 0,
+                            id: k,
+                            icon: app.icon,
+                            name: app.name,
+                            url: app.url
+                        }
+                    }
+                }))
+            }
+
+            let SidebarArray = [];
+            const sidebarObject = await db.query(`SELECT * FROM ${userAccount.cache.sidebar_view}`)
+            const customChannelObject = await db.query(`SELECT * FROM sequenzia_custom_channels`)
+            const userAlbums = await db.query('SELECT x.aid, x.name, x.uri, x.owner, x.privacy, y.* FROM (SELECT x.*, y.eid FROM (SELECT DISTINCT * FROM sequenzia_albums WHERE owner = ? ORDER BY name ASC) AS x LEFT JOIN (SELECT *, ROW_NUMBER() OVER(PARTITION BY aid ORDER BY RAND()) AS RowNo FROM sequenzia_album_items) AS y ON x.aid = y.aid AND y.RowNo=1) x LEFT JOIN (SELECT eid, channel, attachment_hash, attachment_name, cache_proxy FROM kanmi_records) y ON y.eid = x.eid ORDER BY name ASC', [userAccount.discord.user.id])
+            const userArtists = await db.query(`SELECT * FROM (SELECT kanmi_records.attachment_hash, kanmi_records.attachment_name, kanmi_records.cache_proxy, kanmi_records.sizeH, kanmi_records.sizeW, kanmi_records.sizeR, kanmi_records.colorR, kanmi_records.colorG, kanmi_records.colorB, sequenzia_index_artists.id AS artist_id, sequenzia_index_artists.artist, sequenzia_index_artists.name AS artist_full_name, sequenzia_index_artists.url AS artist_url, sequenzia_index_artists.search AS artist_search, sequenzia_index_artists.count AS artist_count, sequenzia_index_artists.last AS artist_last, sequenzia_index_artists.source AS artist_source, sequenzia_index_artists.confidence AS artist_confidence, sequenzia_index_artists.rating AS artist_rating, ${userAccount.cache.channels_view}.* FROM kanmi_records,${userAccount.cache.channels_view}, sequenzia_index_artists  WHERE (sequenzia_index_artists.channelid = ${userAccount.cache.channels_view}.channelid AND kanmi_records.eid = sequenzia_index_artists.last AND kanmi_records.channel = ${userAccount.cache.channels_view}.channelid)) x INNER JOIN (SELECT id AS fav_id, date AS fav_date FROM sequenzia_artists_favorites WHERE userid = "${userAccount.discord.user.id}") y ON x.artist_id = y.fav_id ORDER BY x.artist_last DESC`)
+
+            const libraryLists = await db.query(`SELECT g.* FROM (SELECT * FROM kongou_media_groups) g INNER JOIN (SELECT media_group FROM ${userAccount.cache.channels_view}) a ON (g.media_group = a.media_group) GROUP BY g.media_group`)
+
+            if (sidebarObject && sidebarObject.rows.length > 0) {
+                const superClasses = (e => {
+                    let unique = [];
+                    let distinct = [];
+                    for( let i = 0; i < e.length; i++ ){
+                        if( !unique[e[i].super]){
+                            distinct.push({
+                                super: e[i].super,
+                                super_name: e[i].super_name,
+                                super_icon: e[i].super_icon,
+                                super_uri: e[i].super_uri
+                            });
+                            unique[e[i].super] = 1;
+                        }
+                    }
+                    return distinct
+                })(sidebarObject.rows)
+                const classes = (e => {
+                    let unique = [];
+                    let distinct = [];
+                    for( let i = 0; i < e.length; i++ ){
+                        if( !unique[e[i].class]){
+                            distinct.push({
+                                class: e[i].class,
+                                super: e[i].super,
+                                class_name: e[i].class_name,
+                                class_icon: e[i].class_icon,
+                                class_uri: e[i].class_uri,
+                            });
+                            unique[e[i].class] = 1;
+                        }
+                    }
+                    return distinct
+                })(sidebarObject.rows)
+                const virtualChannels = (e => {
+                    let unique = [];
+                    let distinct = [];
+                    for( let i = 0; i < e.length; i++ ){
+                        if( e[i].virtual_channel_eid !== null && !unique[e[i].virtual_channel_eid] && e[i].virtual_channel_name !== null){
+                            distinct.push({
+                                id: e[i].virtual_channel_eid,
+                                class: e[i].class,
+                                super: e[i].super,
+                                name: e[i].virtual_channel_name,
+                                uri: e[i].virtual_channel_uri,
+                                description: e[i].virtual_channel_description,
+                            });
+                            unique[e[i].virtual_channel_eid] = 1;
+                        }
+                    }
+                    return distinct
+                })(sidebarObject.rows)
+
+                superClasses.forEach((thisSuper) => {
+                    let _items = []
+                    classes.filter(e => e.super === thisSuper.super ).forEach((thisClass) => {
+                        const _channels = sidebarObject.rows.filter(e => e.class === thisClass.class && e.virtual_channel_eid === null).map((thisChannel) => {
+                            let channelName = ''
+                            if (thisChannel.channel_nice === null) {
+                                thisChannel.channel_name.split('-').forEach((wd, i, a) => {
+                                    channelName += wd.substring(0, 1).toUpperCase() + wd.substring(1, wd.length)
+                                    if (i + 1 < a.length) {
+                                        channelName += ' '
+                                    }
+                                })
+                            } else { channelName = thisChannel.channel_nice }
+
+                            return ({
+                                type: 0,
+                                id: thisChannel.channelid,
+                                eid: thisChannel.channel_eid,
+                                name: channelName,
+                                image: (thisChannel.channel_image) ? (thisChannel.channel_image.startsWith('http')) ? thisChannel.channel_image : `https://media.discordapp.net/attachments/${thisChannel.channel_image}`: null,
+                                channel_title: thisChannel.channel_title,
+                                short_name: thisChannel.channel_short_name.split('-').join(' '),
+                                server: thisChannel.serverid,
+                                server_short_name: thisChannel.server_short.toUpperCase(),
+                                nsfw: (thisChannel.channel_nsfw === 1),
+                                uri: thisChannel.channel_uri,
+                                description: thisChannel.channel_description,
+                            })
+                        })
+                        let _mergedChannels = [];
+                        virtualChannels.forEach((vcid) => {
+                            let _vc_entities = [];
+                            let _vc_nsfw = false;
+                            sidebarObject.rows.filter(e => e.class === thisClass.class && vcid.class === thisClass.class && e.virtual_channel_eid !== null && e.virtual_channel_eid === vcid.id).map((thisChannel) => {
+                                let channelName = ''
+                                if (thisChannel.channel_nice === null) {
+                                    thisChannel.channel_name.split('-').forEach((wd, i, a) => {
+                                        channelName += wd.substring(0, 1).toUpperCase() + wd.substring(1, wd.length)
+                                        if (i + 1 < a.length) {
+                                            channelName += ' '
+                                        }
+                                    })
+                                } else {
+                                    channelName = thisChannel.channel_nice
+                                }
+                                if (thisChannel.channel_nsfw === 1) { _vc_nsfw = true; }
+
+                                _vc_entities.push({
+                                    id: thisChannel.channelid,
+                                    eid: thisChannel.channel_eid,
+                                    name: channelName,
+                                    short_name: thisChannel.channel_short_name.split('-').join(' '),
+                                    server: thisChannel.serverid,
+                                    server_short_name: thisChannel.server_short.toUpperCase(),
+                                    uri: thisChannel.channel_uri,
+                                    nsfw: (thisChannel.channel_nsfw === 1),
+                                    description: thisChannel.channel_description,
+                                })
+                            })
+                            if (_vc_entities.length > 0) {
+                                _mergedChannels.push({
+                                    type: 2,
+                                    id: vcid.id,
+                                    name: vcid.name,
+                                    description: vcid.description,
+                                    uri: vcid.uri,
+                                    nsfw: _vc_nsfw,
+                                    entities: _vc_entities
+                                })
+                            }
+                        })
+                        const _customs = customChannelObject.rows.filter((e) => e.class === thisClass.class).map((thisChannel) => {
+                            const channelName = thisChannel.name;
+                            const urlSearch = thisChannel.search + `&title=${channelName}`;
+                            return ({
+                                type: 1,
+                                id: md5(urlSearch),
+                                url: urlSearch,
+                                name: channelName,
+                                nsfw: urlSearch.includes('nsfw=true'),
+                            })
+                        })
+
+                        if (_channels.length > 0) {
+                            _items.push({
+                                id: thisClass.class,
+                                name: thisClass.class_name,
+                                icon: thisClass.class_icon,
+                                uri: thisClass.class_uri,
+                                entities: [..._channels, ..._mergedChannels, ..._customs]
+                            })
+                        }
+                    })
+                    if (_items.length > 0) {
+                        SidebarArray.push({
+                            id: thisSuper.super,
+                            name: thisSuper.super_name,
+                            icon: thisSuper.super_icon,
+                            uri: thisSuper.super_uri,
+                            entities: _items
+                        })
+                    }
+                })
+
+                userAccount.sidebar = SidebarArray;
+
+                if (userAlbums && userAlbums.rows.length > 0) {
+                    userAccount.albums = userAlbums.rows.map(e => {
+                        let ranImage = ( e.cache_proxy) ? e.cache_proxy.startsWith('http') ? e.cache_proxy : `https://media.discordapp.net/attachments${e.cache_proxy}` : (e.attachment_hash && e.attachment_name) ? `https://media.discordapp.net/attachments/` + ((e.attachment_hash.includes('/')) ? e.attachment_hash : `${e.channel}/${e.attachment_hash}/${e.attachment_name}`) : undefined
+                        return {
+                            ...e,
+                            image: ranImage
+                        }
+                    });
+                }
+                if (userArtists && userArtists.rows.length > 0) {
+                    userAccount.artists = userArtists.rows.map(e => {
+                        let latestImage = ( e.cache_proxy) ? e.cache_proxy.startsWith('http') ? e.cache_proxy : `https://media.discordapp.net/attachments${e.cache_proxy}` : (e.attachment_hash && e.attachment_name) ? `https://media.discordapp.net/attachments/` + ((e.attachment_hash.includes('/')) ? e.attachment_hash : `${e.channelid}/${e.attachment_hash}/${e.attachment_name}`) : undefined
+                        return {
+                            ...e,
+                            image: latestImage
+                        }
+                    });
+                }
+                if (libraryLists && libraryLists.rows.length > 0)
+                    userAccount.media_groups = libraryLists.rows
+            }
 
             await db.query(`INSERT INTO  sequenzia_user_cache SET ? ON DUPLICATE KEY UPDATE ?`, [
                 { userid: userId, data: JSON.stringify(userAccount) }, { data: JSON.stringify(userAccount) }

--- a/js/backup.js
+++ b/js/backup.js
@@ -7,7 +7,7 @@
 Developed at Academy City Research
 "Developing a better automated future"
 ======================================================================================
-Kanmi Project - Discord I/O System
+Shutaura Project - Discord I/O System
 Copyright 2020
 ======================================================================================
 This code is under a strict NON-DISCLOSURE AGREEMENT, If you have the rights

--- a/js/discord.js
+++ b/js/discord.js
@@ -7,7 +7,7 @@
 Developed at Academy City Research
 "Developing a better automated future"
 ======================================================================================
-Kanmi Project - Discord I/O System
+Shutaura Project - Discord I/O System
 Copyright 2020
 ======================================================================================
 This code is publicly released and is restricted by its project license

--- a/js/discord.js
+++ b/js/discord.js
@@ -3683,10 +3683,10 @@ This code is publicly released and is restricted by its project license
                                     messageText: "",
                                     messageIntent: 'PullTweets',
                                     messageAction: undefined,
-                                    tweetCount: (args.length > 1) ? args[1] : undefined
+                                    listID: (args.length > 1) ? args[1] : undefined
                                 }, function (ok) {
                                     if (ok)
-                                        SendMessage(`Grabbing ${(args.length > 1) ? args[1] : ''}tweets from lists`, "system", msg.guildID, "TwitterUpdate")
+                                        SendMessage(`Grabbing tweets from ${(args.length > 1) ? 'list ID ' + args[1] : 'lists'}`, "system", msg.guildID, "TwitterUpdate")
                                 })
                                 break;
                             default:

--- a/js/discord.js
+++ b/js/discord.js
@@ -1911,7 +1911,7 @@ This code is publicly released and is restricted by its project license
                                                         })
                                                             .then(async (data) => {
                                                                 if (data.attachments.length > 0) {
-                                                                    const url = data.attachments[0].url.split('/attachments')[0]
+                                                                    const url = data.attachments[0].url.split('/attachments')[1]
                                                                     db.query(`UPDATE discord_users_extended SET banner_custom = ? WHERE id = ?`, [url, MessageContents.userId]);
                                                                     Logger.printLine('SetUserBanner', `User Banner for ${MessageContents.userId} set!`, 'debug')
                                                                 }

--- a/js/discord.js
+++ b/js/discord.js
@@ -1936,7 +1936,7 @@ This code is publicly released and is restricted by its project license
                             }
                             break;
                         default:
-                            SendMessage("No Matching Command for " + MessageContents.messageAction, "Command", ChannelData.guild.id, "warn")
+                            SendMessage("No Matching Command for " + MessageContents.messageAction, "Command", (ChannelData) ? ChannelData.guild.id : "main", "warn")
                             if (MessageContents.messageReturn === true) {
                                 mqClient.sendData(MessageContents.fromClient, failcase, function (ok) {
 

--- a/js/discord.js
+++ b/js/discord.js
@@ -1895,10 +1895,11 @@ This code is publicly released and is restricted by its project license
                                         } else {
                                             sharp(Buffer.from(body))
                                                 .extract({
-                                                    top: MessageContents.imageCrop[0],
-                                                    left: MessageContents.imageCrop[1],
-                                                    height: MessageContents.imageCrop[2],
-                                                    width: MessageContents.imageCrop[3] })
+                                                    top: parseInt(MessageContents.imageCrop[0].toString()),
+                                                    left: parseInt(MessageContents.imageCrop[1].toString()),
+                                                    height: parseInt(MessageContents.imageCrop[2].toString()),
+                                                    width: parseInt(MessageContents.imageCrop[3].toString())
+                                                })
                                                 .toBuffer((err, buffer) => {
                                                     if (err) {
                                                         SendMessage("Failed to crop new banenr with sharp", "err", "main", "SetUserBanner", err)

--- a/js/discord.js
+++ b/js/discord.js
@@ -8617,7 +8617,7 @@ This code is publicly released and is restricted by its project license
                 });
                 cycleThreads(true);
                 init = 1
-                verifySpannedFiles(5);
+                //verifySpannedFiles(5);
                 cleanOldMessages();
                 setInterval(async () => { cleanOldMessages(); }, 3600000);
                 setInterval(async () => { verifySpannedFiles(25); }, 14400000);

--- a/js/discord.js
+++ b/js/discord.js
@@ -1868,7 +1868,7 @@ This code is publicly released and is restricted by its project license
                                 let messagecontent = "Banner Image For " + MessageContents.userId
                                 const moveTo = discordServers.get('homeGuild').chid_filecache
 
-                                Logger.printLine("Rotate", `Need to download ${MessageContents.imageURL}`, "debug", MessageContents.imageURL)
+                                Logger.printLine("SetUserBanner", `Need to download ${MessageContents.imageURL}`, "debug", MessageContents.imageURL)
                                 const result = await new Promise(resolve => {
                                     request.get({
                                         url: MessageContents.imageURL,
@@ -1932,6 +1932,80 @@ This code is publicly released and is restricted by its project license
                                 })
                                 cb((result))
                                 activeTasks.delete(`BANNER_IMG_${MessageContents.userId}`)
+                            } else {
+                                cb(true);
+                            }
+                            break;
+                        case 'SetUserAvatar':
+                            if (MessageContents.imageURL !== undefined && MessageContents.imageCrop !== undefined && MessageContents.imageCrop.length === 4 && MessageContents.userId !== undefined) {
+                                await activeTasks.set(`AVATAR_IMG_${MessageContents.userId}`, { started: Date.now().valueOf() });
+                                let messagecontent = "Avatar Image For " + MessageContents.userId
+                                const moveTo = discordServers.get('homeGuild').chid_filecache
+
+                                Logger.printLine("SetUserAvatar", `Need to download ${MessageContents.imageURL}`, "debug", MessageContents.imageURL)
+                                const result = await new Promise(resolve => {
+                                    request.get({
+                                        url: MessageContents.imageURL,
+                                        headers: {
+                                            'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+                                            'accept-language': 'en-US,en;q=0.9',
+                                            'cache-control': 'max-age=0',
+                                            'sec-ch-ua': '"Chromium";v="92", " Not A;Brand";v="99", "Microsoft Edge";v="92"',
+                                            'sec-ch-ua-mobile': '?0',
+                                            'sec-fetch-dest': 'document',
+                                            'sec-fetch-mode': 'navigate',
+                                            'sec-fetch-site': 'none',
+                                            'sec-fetch-user': '?1',
+                                            'upgrade-insecure-requests': '1',
+                                            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36 Edg/92.0.902.73'
+                                        },
+                                    }, function (err, res, body) {
+                                        if (err) {
+                                            SendMessage("Failed to download message attachments from discord", "err", "main", "SetUserAvatar", err)
+                                            resolve(true);
+                                        } else if (!body || (body && body.length < 100)) {
+                                            SendMessage("Failed to download message attachments from discord", "err", "main", "SetUserAvatar")
+                                            resolve(true);
+                                        } else {
+                                            sharp(Buffer.from(body))
+                                                .extract({
+                                                    top: parseInt(MessageContents.imageCrop[0].toString()),
+                                                    left: parseInt(MessageContents.imageCrop[1].toString()),
+                                                    height: parseInt(MessageContents.imageCrop[2].toString()),
+                                                    width: parseInt(MessageContents.imageCrop[3].toString())
+                                                })
+                                                .toBuffer((err, buffer) => {
+                                                    if (err) {
+                                                        SendMessage("Failed to crop new banenr with sharp", "err", "main", "SetUserAvatar", err)
+                                                        resolve(true)
+                                                    } else {
+                                                        discordClient.createMessage(moveTo, {content: `${messagecontent}`}, {
+                                                            file: buffer,
+                                                            name: `avatar-${MessageContents.userId}.${MessageContents.imageURL.split('.').pop()}`
+                                                        })
+                                                            .then(async (data) => {
+                                                                if (data.attachments.length > 0) {
+                                                                    const url = data.attachments[0].url.split('/attachments')[1]
+                                                                    db.query(`UPDATE discord_users_extended SET avatar_custom = ? WHERE id = ?`, [url, MessageContents.userId]);
+                                                                    Logger.printLine('SetUserAvatar', `User Avatar for ${MessageContents.userId} set!`, 'debug')
+                                                                }
+                                                                resolve(true)
+                                                            })
+                                                            .catch((er) => {
+                                                                SendMessage("Failed to send message to discord", "err", message.guildID, "SetUserAvatar", er)
+                                                                if (er.message.includes("empty message") || er.message.includes("to large")) {
+                                                                    resolve(true)
+                                                                } else {
+                                                                    resolve(true)
+                                                                }
+                                                            });
+                                                    }
+                                                })
+                                        }
+                                    })
+                                })
+                                cb((result))
+                                activeTasks.delete(`AVATAR_IMG_${MessageContents.userId}`)
                             } else {
                                 cb(true);
                             }

--- a/js/discord.js
+++ b/js/discord.js
@@ -7448,7 +7448,8 @@ This code is publicly released and is restricted by its project license
                                             "title": `New Content added to ${channelName}!`
                                         }
                                         if (sqlObject.user !== discordClient) {
-                                            const memberAccount = await db.query(`SELECT * FROM discord_users WHERE id = ? LIMIT 1`, [sqlObject.user])
+
+                                            const memberAccount = await db.query("SELECT x.serveruserid, x.server, x.username, x.avatar, x.banner, x.color, x.`2fa_key`, y.* FROM (SELECT serveruserid, id, server, username, avatar, banner, color, `2fa_key` FROM discord_users) x LEFT JOIN (SELECT * FROM discord_users_extended) y ON (x.id = y.id) WHERE x.id = ? LIMIT 1", [sqlObject.user])
                                             if (memberAccount.error) {
 
                                             } else if (memberAccount.rows.length > 0) {

--- a/js/discord.js
+++ b/js/discord.js
@@ -1929,7 +1929,7 @@ This code is publicly released and is restricted by its project license
                                                                     if (userCache.length > 0) {
                                                                         const _data = userCache[0].data;
                                                                         _data.user.banner = '/full_attachments' + url
-                                                                        await db.query(`UPDATE sequenzia_user_cache SET data = ? WHERE userid = ?`, [MessageContents.userId])
+                                                                        await db.query(`UPDATE sequenzia_user_cache SET data = ? WHERE userid = ?`, [JSON.stringify(_data), MessageContents.userId])
                                                                         Logger.printLine('SetUserBanner', `User Cache for ${MessageContents.userId} updated!`, 'debug')
                                                                     }
                                                                 }
@@ -2011,7 +2011,7 @@ This code is publicly released and is restricted by its project license
                                                                     if (userCache.length > 0) {
                                                                         const _data = userCache[0].data;
                                                                         _data.user.avatar = '/full_attachments' + url
-                                                                        await db.query(`UPDATE sequenzia_user_cache SET data = ? WHERE userid = ?`, [MessageContents.userId])
+                                                                        await db.query(`UPDATE sequenzia_user_cache SET data = ? WHERE userid = ?`, [JSON.stringify(_data), MessageContents.userId])
                                                                         Logger.printLine('SetUserBanner', `User Cache for ${MessageContents.userId} updated!`, 'debug')
                                                                     }
                                                                 }

--- a/js/discord.js
+++ b/js/discord.js
@@ -7080,7 +7080,7 @@ This code is publicly released and is restricted by its project license
         })
     }
     async function verifySpannedFiles(searchLimit) {
-        const files = (await db.query(`SELECT * FROM kanmi_records WHERE fileid IS NOT NULL ORDER BY id DESC LIMIT ${(!searchLimit) ? '50' : searchLimit}`)).rows
+        const files = (await db.query(`SELECT *, CONVERT(kanmi_records.id,SIGNED) AS num_id FROM kanmi_records WHERE fileid IS NOT NULL ORDER BY num_id DESC LIMIT ${(!searchLimit) ? '50' : searchLimit}`)).rows
         if (files && files.length) {
             await activeTasks.set('VERIFY_SFPARTS', { started: Date.now().valueOf() });
             Logger.printLine("MPFValidator", `Validating ${files.length}`, "debug")
@@ -8792,7 +8792,7 @@ This code is publicly released and is restricted by its project license
                 });
                 cycleThreads(true);
                 init = 1
-                //verifySpannedFiles(5);
+                verifySpannedFiles(5);
                 cleanOldMessages();
                 setInterval(async () => { cleanOldMessages(); }, 3600000);
                 setInterval(async () => { verifySpannedFiles(25); }, 14400000);

--- a/js/discord.js
+++ b/js/discord.js
@@ -1911,7 +1911,7 @@ This code is publicly released and is restricted by its project license
                                                         })
                                                             .then(async (data) => {
                                                                 if (data.attachments.length > 0) {
-                                                                    const url = data.attachments[0].url.split('/attachments')
+                                                                    const url = data.attachments[0].url.split('/attachments')[0]
                                                                     db.query(`UPDATE discord_users_extended SET banner_custom = ? WHERE id = ?`, [url, MessageContents.userId]);
                                                                     Logger.printLine('SetUserBanner', `User Banner for ${MessageContents.userId} set!`, 'debug')
                                                                 }

--- a/js/feed.js
+++ b/js/feed.js
@@ -7,7 +7,7 @@
 Developed at Academy City Research
 "Developing a better automated future"
 ======================================================================================
-Kanmi Project - RSS Feed Watcher and Parser
+Shutaura Project - RSS Feed Watcher and Parser
 Copyright 2020
 ======================================================================================
 This code is under a strict NON-DISCLOSURE AGREEMENT, If you have the rights

--- a/js/fileworker.js
+++ b/js/fileworker.js
@@ -1044,7 +1044,7 @@ docutrol@acr.moe - 301-399-3671 - docs.acr.moe/docutrol
 												for (let part of itemsCompleted) {
 													fs.unlink(part, function (err) {
 														if (err && (err.code === 'EBUSY' || err.code === 'ENOENT')) {
-															mqClient.sendMessage(`Error removing file part from temporary folder! - ${err.message}`, "err", "MPFDownload", err)
+															//mqClient.sendMessage(`Error removing file part from temporary folder! - ${err.message}`, "err", "MPFDownload", err)
 														}
 													})
 												}

--- a/js/fileworker.js
+++ b/js/fileworker.js
@@ -7,7 +7,7 @@
 Developed at Academy City Research
 "Developing a better automated future"
 ======================================================================================
-Kanmi Project - FileWorker I/O System
+Shutaura Project - FileWorker I/O System
 Copyright 2020
 ======================================================================================
 This code is under a strict NON-DISCLOSURE AGREEMENT, If you have the rights

--- a/js/pixiv.js
+++ b/js/pixiv.js
@@ -8,7 +8,7 @@
 Developed at Academy City Research
 "Developing a better automated future"
 ======================================================================================
-Kanmi Project - Pixiv I/O System
+Shutaura Project - Pixiv I/O System
 Copyright 2020
 ======================================================================================
 This code is under a strict NON-DISCLOSURE AGREEMENT, If you have the rights

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -1536,10 +1536,10 @@ const systemglobal = require("../config.json");
 					const lasttweet = await db.query(`SELECT tweetid FROM twitter_history_inbound WHERE tweetid = ? LIMIT 1`, [((tweet.retweeted_status && tweet.retweeted_status.id_str)) ? tweet.retweeted_status.id_str : tweet.id_str]);
 					if (lasttweet.rows.length === 0 || message.allowDuplicates) {
 						const competedTweet = await sendTweetToDiscordv2({
-							channelid: `${(message.messageChannelID) ? message.messageChannelID : discordaccount[0].chid_download}`,
+							channelid: message.messageChannelID || message.messageDestinationID || discordaccount[0].chid_download,
 							saveid: message.messageDestinationID || discordaccount[0].chid_download,
-							nsfw: 0,
-							txtallowed: 0,
+							nsfw: message.listNsfw || 0,
+							txtallowed: message.listTxtallowed || 0,
 							fromname: message.listName || "Manual Download",
 							tweet,
 							redirect: message.listRedirect_taccount || 0,
@@ -1863,7 +1863,10 @@ const systemglobal = require("../config.json");
 												excludeReplys: true,
 												allowDuplicates: false,
 
-												messageDestinationID: list.channelid,
+												messageChannelID: list.channelid,
+												listNsfw: (list.nsfw === 1) ? (list.redirect_taccount !== list.taccount) ? 0 : list.nsfw : list.nsfw,
+												listTxtallowed: list.textallowed,
+												messageDestinationID: list.saveid,
 												listName: list.name,
 												listRedirect_taccount: list.redirect_taccount,
 												listBypasscds: list.bypasscds,

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -1836,7 +1836,7 @@ const systemglobal = require("../config.json");
 			const id = e[0];
 			const twit = e[1];
 
-			const twitterlist = await db.query(`SELECT * FROM twitter_list WHERE taccount = ?${(listID) ? " AND listid = '" + listID "'" }`, [id]);
+			const twitterlist = await db.query(`SELECT * FROM twitter_list WHERE taccount = ?${(listID) ? " AND listid = '" + listID "'" : '' }`, [id]);
 			if (twitterlist.error) { console.error(twitterlist.error) }
 
 			let listRequests = twitterlist.rows.reduce((promiseChain, list) => {

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -9,7 +9,7 @@
 Developed at Academy City Research
 "Developing a better automated future"
 ======================================================================================
-Kanmi Project - Twitter I/O System
+Shutaura Project - Twitter I/O System
 Copyright 2020
 ======================================================================================
 This code is under a strict NON-DISCLOSURE AGREEMENT, If you have the rights

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -1537,20 +1537,20 @@ const systemglobal = require("../config.json");
 					if (lasttweet.rows.length === 0 || message.allowDuplicates) {
 						const competedTweet = await sendTweetToDiscordv2({
 							channelid: `${(message.messageChannelID) ? message.messageChannelID : discordaccount[0].chid_download}`,
-							saveid: discordaccount[0].chid_download,
+							saveid: message.messageDestinationID || discordaccount[0].chid_download,
 							nsfw: 0,
 							txtallowed: 0,
-							fromname: "Manual Download",
+							fromname: message.listName || "Manual Download",
 							tweet,
-							redirect: 0,
-							bypasscds: 0,
-							autolike: 0,
-							replyenabled: 0,
-							mergelike: 0,
-							listusers: false,
-							disablelike: 0,
-							list_num: 0,
-							list_id: 0,
+							redirect: message.listRedirect_taccount || 0,
+							bypasscds: message.listBypasscds || 0,
+							autolike: message.listAutolike || 0,
+							replyenabled: message.listReplyenabled || 0,
+							mergelike: message.listMergelike || 0,
+							listusers: message.listUsers || 0,
+							disablelike: message.listDisablelike || 0,
+							list_num: message.listNum || 0,
+							list_id: message.listId || 0,
 							accountid: twitterUser,
 						})
 						if (competedTweet && competedTweet.length > 0) {
@@ -1862,7 +1862,18 @@ const systemglobal = require("../config.json");
 												excludeRT: true,
 												excludeReplys: true,
 												allowDuplicates: false,
-												messageChannelID: list.channelid
+
+												messageDestinationID: list.channelid,
+												listName: list.name,
+												listRedirect_taccount: list.redirect_taccount,
+												listBypasscds: list.bypasscds,
+												listAutolike: list.autolike,
+												listReplyenabled: list.replyenabled,
+												listMergelike: list.mergelike,
+												listUsers: listMembers.users,
+												listDisablelike: list.disablelike,
+												listNum: list.id,
+												listId: list.listid,
 											},(state) => {
 												tweetResolve(state);
 											})

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -1561,7 +1561,7 @@ const systemglobal = require("../config.json");
 									sent = false;
 							}
 							if (lasttweet.rows.length === 0 && sent)
-								await db.query(`INSERT INTO twitter_history_inbound VALUES (?, null, NOW())`, [((tweet.retweeted_status && tweet.retweeted_status.id_str)) ? tweet.retweeted_status.id_str : tweet.id_str])
+								await db.query(`INSERT INTO twitter_history_inbound VALUES (?, ?, NOW())`, [((tweet.retweeted_status && tweet.retweeted_status.id_str)) ? tweet.retweeted_status.id_str : tweet.id_str, message.listId || null])
 						}
 					}
 					tweetResolve(true);

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -1831,12 +1831,12 @@ const systemglobal = require("../config.json");
 			});
 		}
 	}
-	async function downloadMissingTweets() {
+	async function downloadMissingTweets(listID) {
 		Array.from(twitterAccounts.entries()).forEach(async e => {
 			const id = e[0];
 			const twit = e[1];
 
-			const twitterlist = await db.query(`SELECT * FROM twitter_list WHERE taccount = ?`, [id]);
+			const twitterlist = await db.query(`SELECT * FROM twitter_list WHERE taccount = ?${(listID) ? " AND listid = '" + listID "'" }`, [id]);
 			if (twitterlist.error) { console.error(twitterlist.error) }
 
 			let listRequests = twitterlist.rows.reduce((promiseChain, list) => {
@@ -2043,7 +2043,7 @@ const systemglobal = require("../config.json");
 					downloadUser(message, cb);
 					break;
 				case "PullTweets":
-					downloadMissingTweets();
+					downloadMissingTweets(message.listID);
 					cb(true);
 					break;
 				case "SendTweet":

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -1836,7 +1836,7 @@ const systemglobal = require("../config.json");
 			const id = e[0];
 			const twit = e[1];
 
-			const twitterlist = await db.query(`SELECT * FROM twitter_list WHERE taccount = ?${(listID) ? " AND listid = '" + listID "'" : '' }`, [id]);
+			const twitterlist = await db.query(`SELECT * FROM twitter_list WHERE taccount = ?${(listID) ? " AND listid = '" + listID + "'" : "" }`, [id]);
 			if (twitterlist.error) { console.error(twitterlist.error) }
 
 			let listRequests = twitterlist.rows.reduce((promiseChain, list) => {

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -1831,7 +1831,7 @@ const systemglobal = require("../config.json");
 			});
 		}
 	}
-	async function downloadMissingTweets(cb) {
+	async function downloadMissingTweets() {
 		Array.from(twitterAccounts.entries()).forEach(async e => {
 			const id = e[0];
 			const twit = e[1];
@@ -1853,7 +1853,7 @@ const systemglobal = require("../config.json");
 								Logger.printLine("TwitterImport", `Error retrieving twitter ${list.name} (${list.listid})!`, "error", err)
 								listResolve(false);
 							} else {
-								let tweetRequests = listMembers.reduce((promiseChain1, memeber) => {
+								let tweetRequests = listMembers.users.reduce((promiseChain1, memeber) => {
 									return promiseChain1.then(() => new Promise(async (tweetResolve) => {
 										limiter6.removeTokens(1, function () {
 											downloadUser({

--- a/js/updater.js
+++ b/js/updater.js
@@ -236,7 +236,7 @@ const systemglobal = require("../config.json");
         const allApps = activeProc.filter(e => (e.name !== "Updater" || args.install))
         const appNeedToRestart = activeProc.filter(e => (e.name !== "Updater" || args.install) && (systemglobal.AlwaysRestart && systemglobal.AlwaysRestart.indexOf(e.name) !== -1 || filesToUpdate.filter(f => (f === e.pm2_env.pm_exec_path.replace(e.pm2_env.pm_cwd + '/', '') || f.startsWith('js/utils/'))).length > 0) && e.pm2_env.status === "online")
         const dontRestart = appNeedToRestart.filter(e => systemglobal.DontRestart && systemglobal.DontRestart.indexOf(e.name) !== -1)
-        const appToRestart = appNeedToRestart.filter(e => dontRestart.filter(f => f.name === e.name).length === 0)
+        const appToRestart = [...new Set(appNeedToRestart.filter(e => dontRestart.filter(f => f.name === e.name).length === 0))]
         const isNpmUpdatesNeeded = (filesToUpdate.filter(e => e === 'package.json').length > 0)
         const isUpdateSelf = (filesToUpdate.filter(e => e === 'js/updater.js').length > 0)
         const applyPatch = (commits.filter(e => e.includes('APPLYPATCH')).length > 0)
@@ -324,7 +324,7 @@ const systemglobal = require("../config.json");
                         await mqClient.sendMessage(`Successfully applied all required patches for ${(project) ? project : 'sequenzia-framework'}`, 'info', 'GetUpdated');
                     }
                     for (const proc of ((commits.filter(e => e.includes('STAGE0KILL') || e.includes('STAGE1KILL') || e.includes('STAGE2KILL') || e.includes('STAGE3KILL') || e.includes('FULLRESTART')).length > 0 && !systemglobal.DisablePatching && !args.nopatch) ? allApps : appToRestart)) {
-                        if (await restartProccess(proc.id)) {
+                        if (await restartProccess(proc.name)) {
                             await mqClient.sendMessage(`Updated and Restarted ${proc.name} for ${(project) ? project : 'sequenzia-framework'}`, 'info', 'GetUpdated')
                         } else {
                             await mqClient.sendMessage(`Failed to restart system ${proc.name} for ${(project) ? project : 'sequenzia-framework'}`, 'critical', 'GetUpdated')

--- a/js/updater.js
+++ b/js/updater.js
@@ -324,7 +324,7 @@ const systemglobal = require("../config.json");
                         await mqClient.sendMessage(`Successfully applied all required patches for ${(project) ? project : 'sequenzia-framework'}`, 'info', 'GetUpdated');
                     }
                     for (const proc of ((commits.filter(e => e.includes('STAGE0KILL') || e.includes('STAGE1KILL') || e.includes('STAGE2KILL') || e.includes('STAGE3KILL') || e.includes('FULLRESTART')).length > 0 && !systemglobal.DisablePatching && !args.nopatch) ? allApps : appToRestart)) {
-                        if (await restartProccess(proc.name)) {
+                        if (await restartProccess(proc.id)) {
                             await mqClient.sendMessage(`Updated and Restarted ${proc.name} for ${(project) ? project : 'sequenzia-framework'}`, 'info', 'GetUpdated')
                         } else {
                             await mqClient.sendMessage(`Failed to restart system ${proc.name} for ${(project) ? project : 'sequenzia-framework'}`, 'critical', 'GetUpdated')

--- a/js/webCrawer.js
+++ b/js/webCrawer.js
@@ -7,7 +7,7 @@
 Developed at Academy City Research
 "Developing a better automated future"
 ======================================================================================
-Kanmi Project - Web Crawler System
+Shutaura Project - Web Crawler System
 Copyright 2020
 ======================================================================================
 This code is publicly released and is restricted by its project license

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "dependencies": {
         "2fa": "^0.1.2",
         "amqplib": "*",
+        "body-parser": "^1.20.1",
         "cheerio": "^1.0.0-rc.5",
         "chokidar": "*",
         "colors": "^1.4.0",
@@ -22,6 +23,7 @@
         "emoji-strip": "^1.0.1",
         "eris": "github:bsian03/eris#dev",
         "exif": "^0.6.0",
+        "express": "^4.18.2",
         "fast-average-color-node": "^1.0.3",
         "feed-read": "0.0.1",
         "file-type": "^14.6.0",
@@ -37,6 +39,7 @@
         "md5": "^2.3.0",
         "minimist": "^1.2.5",
         "moment": "^2.29.1",
+        "multer": "^1.4.5-lts.1",
         "mysql": "*",
         "mysql2": "^2.3.0",
         "mysqldump": "^3.2.0",
@@ -862,6 +865,18 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
@@ -1016,6 +1031,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+    },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -1085,6 +1105,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -1324,6 +1349,29 @@
       "resolved": "https://registry.npmjs.org/bodec/-/bodec-0.1.0.tgz",
       "integrity": "sha512-Ylo+MAo5BDUq1KA3f3R/MFhh+g8cnHmo8bz3YPGhI1znrMaf77ol1sfvYJzsw3nTE+Y2GryfDxBaR+AqpAkEHQ=="
     },
+    "node_modules/body-parser": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1389,6 +1437,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1737,10 +1796,89 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/continuation-local-storage": {
       "version": "3.2.1",
@@ -1750,6 +1888,19 @@
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
       }
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/cookiejar": {
       "version": "2.1.3",
@@ -1957,6 +2108,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
@@ -2030,6 +2190,11 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
     "node_modules/emitter-listener": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
@@ -2049,6 +2214,14 @@
       "integrity": "sha512-1iU1Bz98ziALBnMTzQHKB104vntCokqgdmJIP9p1eM0Musc3WQ4y8C5noIckorxJ1vihZCTv2lyXMTM1UsemPg==",
       "dependencies": {
         "emoji-regex": "^6.1.3"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/end-of-stream": {
@@ -2095,6 +2268,11 @@
         "opusscript": "^0.0.8",
         "tweetnacl": "^1.0.3"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -2153,6 +2331,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter2": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
@@ -2178,6 +2364,66 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.11.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2313,6 +2559,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/flickr-sdk": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/flickr-sdk/-/flickr-sdk-3.10.0.tgz",
@@ -2372,6 +2635,22 @@
       "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fs-constants": {
@@ -2963,6 +3242,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -3304,6 +3591,19 @@
         "is-buffer": "~1.1.6"
       }
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -3438,6 +3738,34 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -3601,6 +3929,14 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -7990,6 +8326,17 @@
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
       "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8177,6 +8524,14 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path": {
       "version": "0.12.7",
       "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
@@ -8198,6 +8553,11 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "node_modules/peek-readable": {
       "version": "4.1.0",
@@ -8658,6 +9018,18 @@
         "read": "^1.0.4"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
@@ -8783,6 +9155,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
@@ -9169,10 +9549,52 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "node_modules/seq-queue": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -9476,6 +9898,14 @@
       "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
       "dependencies": {
         "debug": "2"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -9919,6 +10349,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -10003,6 +10450,14 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -10010,6 +10465,14 @@
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/verror": {
@@ -10843,6 +11306,15 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "requires": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      }
+    },
     "acorn": {
       "version": "8.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
@@ -10951,6 +11423,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+    },
     "aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -11004,6 +11481,11 @@
           "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
         }
       }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "asn1": {
       "version": "0.2.6",
@@ -11187,6 +11669,25 @@
       "resolved": "https://registry.npmjs.org/bodec/-/bodec-0.1.0.tgz",
       "integrity": "sha512-Ylo+MAo5BDUq1KA3f3R/MFhh+g8cnHmo8bz3YPGhI1znrMaf77ol1sfvYJzsw3nTE+Y2GryfDxBaR+AqpAkEHQ=="
     },
+    "body-parser": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "requires": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      }
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -11232,6 +11733,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "bytes": {
       "version": "3.1.2",
@@ -11487,10 +11996,70 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+    },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "requires": {
+        "safe-buffer": "5.2.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "continuation-local-storage": {
       "version": "3.2.1",
@@ -11500,6 +12069,16 @@
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
       }
+    },
+    "cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "cookiejar": {
       "version": "2.1.3",
@@ -11653,6 +12232,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
+    "destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
     "detect-libc": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
@@ -11705,6 +12289,11 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
     "emitter-listener": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
@@ -11725,6 +12314,11 @@
       "requires": {
         "emoji-regex": "^6.1.3"
       }
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -11755,6 +12349,11 @@
         "tweetnacl": "^1.0.3",
         "ws": "^8.2.3"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -11788,6 +12387,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
     "eventemitter2": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
@@ -11810,6 +12414,51 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
+    "express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "requires": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.11.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
     },
     "extend": {
       "version": "3.0.2",
@@ -11912,6 +12561,20 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      }
+    },
     "flickr-sdk": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/flickr-sdk/-/flickr-sdk-3.10.0.tgz",
@@ -11945,6 +12608,16 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
       "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ=="
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -12388,6 +13061,11 @@
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
     "is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -12671,6 +13349,16 @@
         "is-buffer": "~1.1.6"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -12766,6 +13454,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        }
+      }
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -12916,6 +13628,11 @@
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         }
       }
+    },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "netmask": {
       "version": "2.0.2",
@@ -16151,6 +16868,14 @@
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
       "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
     },
+    "on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -16299,6 +17024,11 @@
         "parse5": "^7.0.0"
       }
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "path": {
       "version": "0.12.7",
       "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
@@ -16317,6 +17047,11 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "peek-readable": {
       "version": "4.1.0",
@@ -16642,6 +17377,15 @@
         "read": "^1.0.4"
       }
     },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
@@ -16744,6 +17488,11 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
       "version": "2.5.1",
@@ -17049,10 +17798,48 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "seq-queue": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -17273,6 +18060,11 @@
       "requires": {
         "debug": "2"
       }
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -17603,6 +18395,20 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -17680,10 +18486,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "2fa": "^0.1.2",
     "amqplib": "*",
+    "body-parser": "^1.20.1",
     "cheerio": "^1.0.0-rc.5",
     "chokidar": "*",
     "colors": "^1.4.0",
@@ -23,6 +24,7 @@
     "emoji-strip": "^1.0.1",
     "eris": "github:bsian03/eris#dev",
     "exif": "^0.6.0",
+    "express": "^4.18.2",
     "fast-average-color-node": "^1.0.3",
     "feed-read": "0.0.1",
     "file-type": "^14.6.0",
@@ -38,6 +40,7 @@
     "md5": "^2.3.0",
     "minimist": "^1.2.5",
     "moment": "^2.29.1",
+    "multer": "^1.4.5-lts.1",
     "mysql": "*",
     "mysql2": "^2.3.0",
     "mysqldump": "^3.2.0",


### PR DESCRIPTION
* Rebranding Kanmi to Shutaura (Yes this conflicts with Shutaura SQL internally)
* All user view generation and cacheing for Sequenzia is now handled by AuthWare (Sequenzia is considered acess/read-only)
* AuthWare supports custom reaction roles and role approval notifications
* SBI are added to Discord and AuthWare but are not used yet
* Discord now writes the CMS actions to the tweets table and will not drop the records anymore for analytics 
* Added pull command to pull any missing tweets for a twitter list
* Added support to set custom user banners and avatars
* Squashed the error message from the FileWorker on unable to delete temp files